### PR TITLE
fixed callback name for detaching element

### DIFF
--- a/core-signals.html
+++ b/core-signals.html
@@ -42,7 +42,7 @@ of where they are in DOM.
     attached: function() {
       signals.push(this);
     },
-    removed: function() {
+    detached: function() {
       var i = signals.indexOf(this);
       if (i >= 0) {
         signals.splice(i, 1);


### PR DESCRIPTION
Callback method for when a core-signals element is removed from the DOM is 'detached' not 'removed'.
